### PR TITLE
Add German (de_de) and French (fr_fr) localizations

### DIFF
--- a/Common/src/main/resources/assets/echochest/lang/de_de.json
+++ b/Common/src/main/resources/assets/echochest/lang/de_de.json
@@ -1,0 +1,5 @@
+{
+  "block.echochest.echo_chest": "Echo-Truhe",
+  "block.echochest.echo_chest.description": "Sammelt Gegenstände und Erfahrung von Mobs, die in einem Radius von 8 Blöcken in der Nähe fallen.",
+  "container.echo_chest": "Echo-Truhe"
+}

--- a/Common/src/main/resources/assets/echochest/lang/fr_fr.json
+++ b/Common/src/main/resources/assets/echochest/lang/fr_fr.json
@@ -1,0 +1,5 @@
+{
+  "block.echochest.echo_chest": "Écho de coffre",
+  "block.echochest.echo_chest.description": "Collecte des objets et de l'expérience des mobs tombés à proximité dans un rayon de 8 blocs.",
+  "container.echo_chest": "Coffre Écho"
+}


### PR DESCRIPTION
Hey! I noticed the mod didn't have German or French translations yet, so I went ahead and generated them.

I built a custom parser called Universal Mod-Porter (https://www.universalmodporter.com) specifically to handle Minecraft's internal formatting tokens without breaking the JSON structure, so any § codes and %s variables in the tooltips should be perfectly intact.

Let me know if everything looks good, or if you want me to run any other languages through the tool for you!